### PR TITLE
Fix: 팬 레터 추가 에러 및 선택된 멤버의 팬레터 목록 에러 수정

### DIFF
--- a/src/Redux/config/configStore.js
+++ b/src/Redux/config/configStore.js
@@ -1,18 +1,16 @@
 import { createStore, combineReducers } from 'redux';
 import fanLetterReducer from '../modules/Reducer';
 
-const setLocalState = localStorage.getItem('fanLetters')
-    ? JSON.parse(localStorage.getItem('fanLetters'))
-    : {};
+const setLocalState = localStorage.getItem('fanLetters') ? JSON.parse(localStorage.getItem('fanLetters')) : {};
 
 const rootReducer = combineReducers({
-    fanLetters: fanLetterReducer, // 'fanLetterReducer' 리듀서가 'fanLetters' 상태를 관리
+  fanLetters: fanLetterReducer // 'fanLetterReducer' 리듀서가 'fanLetters' 상태를 관리
 });
 
+// createStore는 deprecated(더 이상 사용하지 않고 redux-toolkit 사용을 권장) https://redux.js.org/api/createstore
 const store = createStore(
-    rootReducer,
-    { fanLetters: setLocalState }, // 초기 상태 설정
+  rootReducer,
+  [{ fanLetters: setLocalState }] // https://redux.js.org/api/createstore 배열의 첫번째 인자로 넣음
 );
-
 
 export default store;

--- a/src/Redux/modules/Reducer.js
+++ b/src/Redux/modules/Reducer.js
@@ -6,7 +6,6 @@ import {
   SET_MODAL_MESSAGE
 } from './actionTypes';
 
-
 const initialState = {
   fanLetters: JSON.parse(localStorage.getItem('fanLetters')) || {},
   showModal: false,
@@ -17,6 +16,7 @@ export const fanLetterReducer = (state = initialState, action) => {
   switch (action.type) {
     case ADD_FAN_LETTER:
       const { member } = action.payload;
+
       const newFanLetters = {
         ...state.fanLetters,
         [member]: [
@@ -24,7 +24,7 @@ export const fanLetterReducer = (state = initialState, action) => {
           {
             nickname: action.payload.nickname,
             content: action.payload.content,
-            color: action.payload.color,
+            color: action.payload.color
           }
         ]
       };
@@ -37,8 +37,8 @@ export const fanLetterReducer = (state = initialState, action) => {
     case UPDATE_FAN_LETTER:
       const { id, newContent } = action.payload;
       const updatedFanLetters = { ...state.fanLetters };
-      Object.keys(updatedFanLetters).forEach(member => {
-        updatedFanLetters[member] = updatedFanLetters[member].map(letter => {
+      Object.keys(updatedFanLetters).forEach((member) => {
+        updatedFanLetters[member] = updatedFanLetters[member].map((letter) => {
           if (letter.id === id) {
             return { ...letter, content: newContent };
           }
@@ -74,7 +74,6 @@ export const fanLetterReducer = (state = initialState, action) => {
         ...state,
         modalMessage: action.payload
       };
-
     default:
       return state;
   }

--- a/src/assets/ProfileIcon.jsx
+++ b/src/assets/ProfileIcon.jsx
@@ -5,12 +5,12 @@ export const ProfileIcon = () => {
       width="40"
       height="40"
       fill="grey"
-      class="bi bi-person-circle"
+      className="bi bi-person-circle"
       viewBox="0 0 16 16"
     >
       <path d="M11 6a3 3 0 1 1-6 0 3 3 0 0 1 6 0" />
       <path
-        fill-rule="evenodd"
+        fillRule="evenodd"
         d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8m8-7a7 7 0 0 0-5.468 11.37C3.242 11.226 4.805 10 8 10s4.757 1.225 5.468 2.37A7 7 0 0 0 8 1"
       />
     </svg>

--- a/src/components/FanLetterList.jsx
+++ b/src/components/FanLetterList.jsx
@@ -22,7 +22,9 @@ function FanLetterList({ selectedMember }) {
 
   useEffect(() => {
     // selectedMember 또는 memberName이 변경될 때 실행
-    const lettersToShow = selectedMember ? fanLetters[selectedMember] || [] : Object.values(fanLetters || {}).flat();
+    const lettersToShow = selectedMember
+      ? fanLetters[selectedMember] || []
+      : Object.values(fanLetters.fanLetters || {}).flat();
     setFilteredFanLetters(lettersToShow);
   }, [fanLetters, selectedMember, memberName]);
 
@@ -34,8 +36,8 @@ function FanLetterList({ selectedMember }) {
   return (
     <ListBodyStyle>
       <ListTitleStyle>{memberToShow}님께 온 팬레터</ListTitleStyle>
-      {filteredFanLetters.map((letter) => (
-        <ListContentStyle key={letter.id} onClick={() => handleLetterClick(letter.id)}>
+      {filteredFanLetters.map((letter, idx) => (
+        <ListContentStyle key={idx} onClick={() => handleLetterClick(letter.id)}>
           <ListNameTimeStyle>
             <LetterImgNameStyle>
               <ProfileIcon />

--- a/src/components/InputFanLetter.jsx
+++ b/src/components/InputFanLetter.jsx
@@ -38,7 +38,6 @@ function InputFanLetter() {
     }
 
     // 팬레터 추가 Redux 액션 디스패치
-    console.log('addFanLetter with member:', selectedMember);
     dispatch(addFanLetter(nickname, content, selectedMember));
     setNickname('');
     setContent('');


### PR DESCRIPTION
- createStore의 두번째 인자로 넘기는 preloadedState 설정 수정
- FanLetterList의 useEffect 안에 선택된 멤버의 펜레터 가져오는 로직 수정

redux 패키지의 [createStore는 deprecated](https://redux.js.org/api/createstore) 됨. 나중엔 [redux-toolkit](https://redux-toolkit.js.org/)을 쓰세용 